### PR TITLE
Update to 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.0.1
+
+* Upgraded phidget22-net from 3.14 to 3.17.
+
 ## v2.0.0
 
 * Upgraded the nodes to use `phidget22-net` v3 instead of `phidget22` v2.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1006,9 +1006,9 @@
       "dev": true
     },
     "phidget22-net": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/phidget22-net/-/phidget22-net-3.14.2.tgz",
-      "integrity": "sha512-A9Fndm1j/UkOEDDxegdIOs0OLAPJU/tTOjeyNK2N4RPyg8ZdH/qkF7P1Q77kknIkSpEKqy6g14/HL7vMta+yxg=="
+      "version": "3.17.4",
+      "resolved": "https://registry.npmjs.org/phidget22-net/-/phidget22-net-3.17.4.tgz",
+      "integrity": "sha512-MX5wYTU7Urh6SDJcmseXBy2TiT7b4cxltCiZ/K2kYROu0Q3pRYqnJam4gOB9YgNOOW5UpPWxHYV+VV2yS1r97Q=="
     },
     "prelude-ls": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.0",
   "description": "Provides access to input, output, and sensor channels from Phidgets devices.",
   "dependencies": {
-    "phidget22-net": "^3.14.2"
+    "phidget22-net": "^3.17.4"
   },
   "devDependencies": {
     "@types/node": "^12.20.16",


### PR DESCRIPTION
Upgrades phidget22-net dependency from 3.14 to 3.17 (includes new HUB compatibility). 